### PR TITLE
Fix AI referencing wrong content in Week 3 assessments

### DIFF
--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -2,9 +2,16 @@
 
 TUTOR_SYSTEM_PROMPT = """# 🎓 Tutor System Prompt
 
-You are a humanities professor guiding a student in a thoughtful, spoken-style conversation about assigned public policy and political theory readings.  
+You are a humanities professor guiding a student in a thoughtful, spoken-style conversation about assigned public policy and political theory readings.
 
-You will always receive **the week's readings as context**. Your job is to draw your questions and comments directly from those readings.  
+You will always receive **the week's readings as context**. Your job is to draw your questions and comments directly from those readings.
+
+## ⚠️ CRITICAL INSTRUCTION: Use ONLY the Provided Readings
+**IMPORTANT**: The example questions below mention specific philosophers like Aristotle, Locke, Jefferson, etc. These are ONLY formatting examples to show question styles. You MUST:
+- Ask questions based EXCLUSIVELY on the actual PDF content provided for this week
+- NEVER use the example philosophers/topics unless they appear in this week's actual readings
+- Before asking any question, verify it relates to the specific texts in the provided reading context
+- Each question must reference actual concepts, authors, or ideas from the PROVIDED READINGS, not from the example templates
 
 ---
 
@@ -40,26 +47,28 @@ You will always receive **the week's readings as context**. Your job is to draw 
 
 ---
 
-## Sample Conversational Questions
+## Sample Conversational Questions (FORMAT EXAMPLES ONLY - Not Actual Content)
+
+**⚠️ REMINDER: These examples use placeholder names like Aristotle, Locke, etc. Do NOT use these unless they appear in the actual week's readings. Replace with the actual authors and concepts from the PROVIDED PDFs.**
 
 ### Clarifying the Text
-- "Aristotle says the city exists not just to survive but to 'live well.' What do you think he means by that?"  
-- "He calls humans 'political animals.' How does that add to your idea of community?"  
-- "Locke says government rests on consent. How would you put that in your own words?"  
-- "Jefferson says all men are created equal. How does that fit with what was happening at the time?"  
+- "[AUTHOR from the reading] says [CONCEPT]. What do you think they mean by that?"
+- "The text mentions [SPECIFIC IDEA from the PDF]. How does that add to your understanding?"
+- "[THEORIST in the reading] argues [POSITION]. How would you put that in your own words?"
+- "The reading discusses [HISTORICAL EVENT/CONTEXT]. How does that fit with [RELATED CONCEPT]?"
 
 ### Challenging or Complicating
-- "That's one way to see it. But Aristotle also says law should make citizens good — how does that fit with your answer?"  
-- "You tied it to survival. But what about justice — how does that change the picture?"  
-- "Locke talks about consent. But what about his state of nature — does that strengthen or weaken his point?"  
-- "Du Bois talks about a 'double consciousness.' Do you see that as more of a strength or more of a burden?"  
+- "That's one way to see it. But [AUTHOR from reading] also says [CONTRASTING POINT] — how does that fit with your answer?"
+- "You tied it to [STUDENT'S POINT]. But what about [DIFFERENT CONCEPT from the reading] — how does that change the picture?"
+- "[AUTHOR] talks about [CONCEPT A]. But what about their view on [CONCEPT B] — does that strengthen or weaken their point?"
+- "The text presents [IDEA]. Do you see that as more of a [OPTION A] or more of a [OPTION B]?"
 
 ### Applying and Pivoting
-- "He defines a citizen as someone who shares in judgment and office. Do you think voting alone makes someone a full citizen by that definition?"  
-- "Aristotle compares households to city-states. Why do you think he insists they aren't the same?"  
-- "He says anyone who lives outside the polis is 'either a beast or a god.' What do you think he meant by that?"  
-- "MLK says an unjust law is one out of harmony with moral law. Do you think that still works as a definition today?"  
-- "If we brought Aristotle's idea of 'living well' into New York City today, what part of civic life would you point to as an example?"  
+- "[AUTHOR] defines [TERM] as [DEFINITION from reading]. Do you think [MODERN APPLICATION] fits that definition?"
+- "The reading compares [CONCEPT A] to [CONCEPT B]. Why do you think the author insists they aren't the same?"
+- "[AUTHOR] claims [BOLD STATEMENT from the text]. What do you think they meant by that?"
+- "The text argues [PRINCIPLE]. Do you think that still works as a framework today?"
+- "If we applied [CONCEPT from reading] to [CONTEMPORARY CONTEXT], what would that look like?"  
 
 ---
 
@@ -104,10 +113,10 @@ Evaluate Effectiveness & Fairness: [Green/Yellow/Red]  [bullet]
 Propose and Justify Reforms: [Green/Yellow/Red]  [bullet]  
 Overall: [Green/Yellow/Red]  
 
-### Example Output  
-Explain and Apply Institutions & Principles: Green – Student explained Locke’s consent theory with evidence and contrasted it to Hobbes.  
-Interpret and Compare Theories & Justifications: Yellow – Student mentioned Aristotle and Locke but only in broad terms.  
-Evaluate Effectiveness & Fairness: Red – Student gave vague opinions without evidence.  
-Propose and Justify Reforms: Red – No reform ideas were discussed.  
-Overall: Yellow  
+### Example Output
+Explain and Apply Institutions & Principles: Green – Student explained [specific theory from reading] with evidence and contrasted it to [alternative view from reading].
+Interpret and Compare Theories & Justifications: Yellow – Student mentioned key authors from the actual readings but only in broad terms.
+Evaluate Effectiveness & Fairness: Red – Student gave vague opinions without evidence from the texts.
+Propose and Justify Reforms: Red – No reform ideas were discussed.
+Overall: Yellow
 """

--- a/backend/test_week3_fix.py
+++ b/backend/test_week3_fix.py
@@ -1,0 +1,81 @@
+"""Test script to verify Week 3 readings are properly referenced"""
+import sys
+import os
+sys.path.append('.')
+from ai_service import AITutorService
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+def test_week3_assessment():
+    """Test that AI properly references Week 3 content, not example philosophers"""
+
+    ai_service = AITutorService()
+    session_id = "test_week3_session"
+
+    # Initialize with Week 3 PDFs
+    print("\n1. Initializing session with Week 3 PDF...")
+    pdf_paths = ["week3/reading1.pdf"]
+    result = ai_service.initialize_session(session_id, pdf_paths)
+
+    if not result['success']:
+        print(f"❌ Failed to initialize: {result}")
+        return
+
+    print(f"✅ Session initialized with Week 3 PDFs")
+
+    # Test conversation
+    print("\n2. Testing AI responses to ensure they reference actual Week 3 content...")
+
+    # First message
+    response1, metadata1 = ai_service.get_ai_response(
+        session_id,
+        "Hi, I'm ready to discuss this week's readings."
+    )
+
+    print(f"\nAI Response 1:\n{response1}")
+
+    # Check if response mentions generic philosophers from examples
+    wrong_refs = ["Aristotle", "Locke", "Jefferson", "MLK", "Du Bois", "Hobbes"]
+    issues = []
+    for ref in wrong_refs:
+        if ref.lower() in response1.lower():
+            issues.append(ref)
+
+    if issues:
+        print(f"\n⚠️ WARNING: AI mentioned example philosophers not in Week 3: {issues}")
+        print("The AI should only reference content from the actual Week 3 PDF!")
+    else:
+        print(f"\n✅ Good! AI did not mention example philosophers")
+
+    # Second message to see follow-up
+    response2, metadata2 = ai_service.get_ai_response(
+        session_id,
+        "I think the main ideas in the reading relate to how societies organize themselves and the role of institutions."
+    )
+
+    print(f"\nAI Response 2:\n{response2}")
+
+    # Check second response
+    issues2 = []
+    for ref in wrong_refs:
+        if ref.lower() in response2.lower():
+            issues2.append(ref)
+
+    if issues2:
+        print(f"\n⚠️ WARNING: AI still mentioning example philosophers: {issues2}")
+    else:
+        print(f"\n✅ Good! AI focused on actual reading content")
+
+    # Summary
+    print("\n" + "="*60)
+    print("TEST SUMMARY:")
+    if not issues and not issues2:
+        print("✅ SUCCESS: AI is properly referencing Week 3 content only")
+    else:
+        print("⚠️ ISSUE: AI is still using example philosophers instead of actual reading content")
+        print("The prompt changes may need further refinement.")
+    print("="*60)
+
+if __name__ == "__main__":
+    test_week3_assessment()

--- a/backend/validate_prompt_fix.py
+++ b/backend/validate_prompt_fix.py
@@ -1,0 +1,79 @@
+"""Validate that the prompts have been updated correctly"""
+
+def check_prompt_updates():
+    """Check that prompts no longer have hardcoded philosopher names in questions"""
+
+    with open('prompts.py', 'r') as f:
+        content = f.read()
+
+    print("=" * 60)
+    print("VALIDATING PROMPT UPDATES")
+    print("=" * 60)
+
+    # Check for critical instruction
+    if "CRITICAL INSTRUCTION: Use ONLY the Provided Readings" in content:
+        print("✅ Critical instruction added to use only provided readings")
+    else:
+        print("❌ Missing critical instruction")
+
+    # Check for warning about examples
+    if "These are ONLY formatting examples" in content:
+        print("✅ Warning added that examples are just formatting")
+    else:
+        print("❌ Missing warning about examples")
+
+    # Check that Aristotle examples are replaced with placeholders
+    example_section = content[content.find("Sample Conversational Questions"):content.find("## Goal")]
+
+    old_examples = [
+        '"Aristotle says the city',
+        '"He calls humans',
+        '"Locke says government',
+        '"Jefferson says all men',
+        '"MLK says an unjust',
+        'Du Bois talks about'
+    ]
+
+    found_old = []
+    for ex in old_examples:
+        if ex in example_section:
+            found_old.append(ex)
+
+    if found_old:
+        print(f"❌ Still has old hardcoded examples: {found_old[:2]}...")
+    else:
+        print("✅ Old hardcoded philosopher examples removed")
+
+    # Check for new placeholder format
+    placeholders = ["[AUTHOR", "[CONCEPT", "[THEORIST", "[SPECIFIC IDEA"]
+    found_placeholders = []
+    for p in placeholders:
+        if p in example_section:
+            found_placeholders.append(p)
+
+    if found_placeholders:
+        print(f"✅ New placeholder format found: {found_placeholders[:3]}...")
+    else:
+        print("❌ Missing new placeholder format")
+
+    # Check evaluation prompt
+    if "Aristotle and Locke but only in broad terms" in content:
+        print("❌ Evaluation still mentions Aristotle and Locke")
+    else:
+        print("✅ Evaluation prompt updated to remove specific names")
+
+    print("\n" + "=" * 60)
+    print("SUMMARY:")
+
+    if "[AUTHOR" in example_section and "CRITICAL INSTRUCTION" in content:
+        print("✅ SUCCESS: Prompts have been properly updated!")
+        print("   - Examples now use generic placeholders")
+        print("   - Clear instructions to use only provided readings")
+        print("   - AI should now reference Week 3 content, not Aristotle")
+    else:
+        print("⚠️ PARTIAL: Some updates made but may need review")
+
+    print("=" * 60)
+
+if __name__ == "__main__":
+    check_prompt_updates()


### PR DESCRIPTION
- Added critical instructions to use ONLY provided PDF content
- Replaced hardcoded philosopher names (Aristotle, Locke, etc.) with generic placeholders
- Added warnings that example questions are formatting templates only
- Updated evaluation prompt to remove specific philosopher references

This ensures AI asks questions based on actual Week 3 readings, not example templates

🤖 Generated with [Claude Code](https://claude.ai/code)